### PR TITLE
Add functionality for table definition metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ client = DataverseRestClient() # configuration is automatically loaded
 entry = client.get_entry(table, entry_id)
 ```
 
-The client provides the following methods:
+The client provides the following methods for basic database interaction:
 ```python
 add_entry(table: str, data: dict) -> dict ...
 
@@ -62,7 +62,19 @@ query(
   order_by: Optional[str | list[str]] = None, # Column or list of columns to order by
   top: Optional[int] = None, # Return the top n results
   select: Optional[str | list[str]] = None # Columns to include in the response
+  expand: Optional[str | list[str]] = None # Related entities to include in the response.
 ) -> list[dict]: ...
+```
+
+There are also these methods for inspecting database table definitions:
+```python
+list_table_names(filter_by_prefix: str = "") -> list[TableMetadata] # lists all table names in the database
+table_info(table_name: str | TableMetadata, column_filter_prefix: str = "") -> TableMetadata # Get full definition including columns
+list_table_info(
+  table_filter_prefix: str = "",
+  column_filter_prefix: str = "",
+  output_file: Optional[Path] = None,
+) -> list[TableMetadata]: # Get full definitions of many tables
 ```
 
 ## REST API and Queries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "dataverse-client"
 description = "Simple client for interacting with MS Dataverse via REST API"
-version = "0.1.0"
+version = "0.1.1"
 license = {text = "MIT"}
 requires-python = ">=3.10"
 authors = [

--- a/src/dataverse_client/__init__.py
+++ b/src/dataverse_client/__init__.py
@@ -4,7 +4,12 @@ from importlib.metadata import version
 
 __version__ = version("dataverse_client")
 
-from .rest_client import DataverseConfig, DataverseRestClient
+from .rest_client import DataverseConfig, DataverseRestClient, ColumnMetadata, TableMetadata
 
 
-__all__ = ["DataverseConfig", "DataverseRestClient"]
+__all__ = [
+    "DataverseConfig",
+    "DataverseRestClient",
+    "ColumnMetadata",
+    "TableMetadata",
+]

--- a/src/dataverse_client/rest_client.py
+++ b/src/dataverse_client/rest_client.py
@@ -3,10 +3,11 @@
 import logging
 from pathlib import Path
 from typing import Optional
+import json
 
 import msal
 from platformdirs import site_data_dir
-from pydantic import SecretStr, computed_field
+from pydantic import BaseModel, SecretStr, computed_field
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -100,6 +101,24 @@ class DataverseConfig(
         )
 
 
+#### Simple models for database table metadata
+
+
+class ColumnMetadata(BaseModel):
+    MetadataId: str
+    LogicalName: str
+    AttributeType: str
+
+
+class TableMetadata(BaseModel):
+    SchemaName: str
+    LogicalCollectionName: str
+    Attributes: Optional[list[ColumnMetadata]] = None
+
+
+####
+
+
 class DataverseRestClient:
     """Client for basic CRUD operations on Dataverse entities."""
 
@@ -136,6 +155,7 @@ class DataverseRestClient:
             "Accept": "application/json",
             "If-None-Match": None,
             "Content-Type": "application/json",
+            "Prefer": 'odata.include-annotations="OData.Community.Display.V1.FormattedValue",return=representation',
         }
 
     def _get_access_token(self) -> str:
@@ -387,7 +407,7 @@ class DataverseRestClient:
         # returns a list of values, and wouldn't include the "@odata.count" property anyway
         response = requests.get(
             url,
-            headers=self.headers | {"Prefer": "return=representation"},
+            headers=self.headers,  # | {"Prefer": "return=representation"},
             timeout=self.config.request_timeout_s,
         )
         logger.debug(
@@ -396,3 +416,85 @@ class DataverseRestClient:
         )
         response.raise_for_status()
         return response.json().get("value", [])
+
+    def list_table_names(self, filter_by_prefix: str = "") -> list[TableMetadata]:
+        """List all table names in the Dataverse environment, optionally filtering by prefix.
+        For each table, return the logical name and the display name (schema name)
+
+        Args:
+            filter_by_prefix: If provided, only return tables whose logical name starts with this prefix.
+        Returns:
+            list[TableMetadata]: List of table metadata objects with no column information
+        """
+        data = self.query("EntityDefinitions", select=["SchemaName", "LogicalCollectionName"])
+        tables = [TableMetadata(**t) for t in data if t["LogicalCollectionName"] is not None]
+        if filter_by_prefix:
+            tables = [t for t in tables if t.LogicalCollectionName.startswith(filter_by_prefix)]
+        return tables
+
+    def table_info(
+        self,
+        table_name: str | TableMetadata,
+        column_filter_prefix: str = "",
+    ) -> TableMetadata:
+        """Get metadata for a Dataverse table, including column names and types.
+
+        Args:
+            table_name: The logical name of the table or a TableMetadata object.
+            column_filter_prefix: If provided, only include columns whose logical name starts with this prefix.
+        Returns:
+            TableMetadata: Metadata for the specified table, including column information
+        """
+        if isinstance(table_name, TableMetadata):
+            table_name = table_name.LogicalCollectionName
+        data = self.query(
+            "EntityDefinitions",
+            filter=f"LogicalCollectionName eq '{table_name}'",
+            select=["SchemaName", "LogicalCollectionName"],
+            expand="Attributes($select=LogicalName,AttributeType)",
+        )[0]
+        table = TableMetadata(**data)
+        if column_filter_prefix:
+            table.Attributes = [
+                a for a in table.Attributes or [] if a.LogicalName.startswith(column_filter_prefix)
+            ]
+        return table
+
+    def list_table_info(
+        self,
+        table_filter_prefix: str = "",
+        column_filter_prefix: str = "",
+        output_file: Optional[Path] = None,
+    ) -> list[TableMetadata]:
+        """Get table metadata for all tables, optionally filtering table logical name by prefix.
+        Microsoft doesn't let you filter metadata by "starts_with(...)" so we have to filter on our own.
+
+        Args:
+            table_filter_prefix: If provided, only include tables whose logical name starts with this prefix.
+            column_filter_prefix: If provided, only include columns whose logical name starts with this prefix.
+            output_file: If provided, write the metadata to this file in JSON format.
+        Returns:
+            list[TableMetadata]: List of table metadata objects, including column information
+        """
+        all_tables = self.query(
+            "EntityDefinitions",
+            select=["SchemaName", "LogicalCollectionName"],
+            expand="Attributes($select=LogicalName,AttributeType)",
+        )
+        if table_filter_prefix:
+            tables_of_interest = [
+                TableMetadata(**t)
+                for t in all_tables
+                if t["LogicalCollectionName"] is not None
+                and t["LogicalCollectionName"].startswith(table_filter_prefix)
+            ]
+        if column_filter_prefix:
+            for t in tables_of_interest:
+                t.Attributes = [
+                    a for a in t.Attributes or [] if a.LogicalName.startswith(column_filter_prefix)
+                ]
+        if output_file:
+            Path(output_file).parent.mkdir(exist_ok=True, parents=True)
+            with open(output_file, "w") as f:
+                json.dump([t.model_dump() for t in tables_of_interest], f, indent=2)
+        return tables_of_interest

--- a/src/dataverse_client/rest_client.py
+++ b/src/dataverse_client/rest_client.py
@@ -407,7 +407,7 @@ class DataverseRestClient:
         # returns a list of values, and wouldn't include the "@odata.count" property anyway
         response = requests.get(
             url,
-            headers=self.headers,  # | {"Prefer": "return=representation"},
+            headers=self.headers,
             timeout=self.config.request_timeout_s,
         )
         logger.debug(
@@ -428,8 +428,7 @@ class DataverseRestClient:
         """
         data = self.query("EntityDefinitions", select=["SchemaName", "LogicalCollectionName"])
         tables = [TableMetadata(**t) for t in data if t["LogicalCollectionName"] is not None]
-        if filter_by_prefix:
-            tables = [t for t in tables if t.LogicalCollectionName.startswith(filter_by_prefix)]
+        tables = [t for t in tables if t.LogicalCollectionName.startswith(filter_by_prefix)]
         return tables
 
     def table_info(
@@ -454,10 +453,11 @@ class DataverseRestClient:
             expand="Attributes($select=LogicalName,AttributeType)",
         )[0]
         table = TableMetadata(**data)
-        if column_filter_prefix:
-            table.Attributes = [
-                a for a in table.Attributes or [] if a.LogicalName.startswith(column_filter_prefix)
-            ]
+        if table.Attributes is None:  # Ensure Attributes is the right type
+            table.Attributes = []
+        table.Attributes = [
+            a for a in table.Attributes if a.LogicalName.startswith(column_filter_prefix)
+        ]
         return table
 
     def list_table_info(
@@ -481,18 +481,18 @@ class DataverseRestClient:
             select=["SchemaName", "LogicalCollectionName"],
             expand="Attributes($select=LogicalName,AttributeType)",
         )
-        if table_filter_prefix:
-            tables_of_interest = [
-                TableMetadata(**t)
-                for t in all_tables
-                if t["LogicalCollectionName"] is not None
-                and t["LogicalCollectionName"].startswith(table_filter_prefix)
+        tables_of_interest = [
+            TableMetadata(**t)
+            for t in all_tables
+            if t["LogicalCollectionName"] is not None
+            and t["LogicalCollectionName"].startswith(table_filter_prefix)
+        ]
+        for t in tables_of_interest:
+            if t.Attributes is None:
+                t.Attributes = []
+            t.Attributes = [
+                a for a in t.Attributes if a.LogicalName.startswith(column_filter_prefix)
             ]
-        if column_filter_prefix:
-            for t in tables_of_interest:
-                t.Attributes = [
-                    a for a in t.Attributes or [] if a.LogicalName.startswith(column_filter_prefix)
-                ]
         if output_file:
             Path(output_file).parent.mkdir(exist_ok=True, parents=True)
             with open(output_file, "w") as f:


### PR DESCRIPTION
It's handy to be able to query the metadata endpoints to learn about dataverse tables so this adds that. The more important thing though is using this to generate models https://github.com/AllenNeuralDynamics/dataverse-client/pull/9