### PR TITLE
Add codegen models

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ client = DataverseRestClient() # configuration is automatically loaded
 entry = client.get_entry(table, entry_id)
 ```
 
-The client provides the following methods:
+The client provides the following methods for basic database interaction:
 ```python
 add_entry(table: str, data: dict) -> dict ...
 
@@ -62,7 +62,19 @@ query(
   order_by: Optional[str | list[str]] = None, # Column or list of columns to order by
   top: Optional[int] = None, # Return the top n results
   select: Optional[str | list[str]] = None # Columns to include in the response
+  expand: Optional[str | list[str]] = None # Related entities to include in the response.
 ) -> list[dict]: ...
+```
+
+There are also these methods for inspecting database table definitions:
+```python
+list_table_names(filter_by_prefix: str = "") -> list[TableMetadata] # lists all table names in the database
+table_info(table_name: str | TableMetadata, column_filter_prefix: str = "") -> TableMetadata # Get full definition including columns
+list_table_info(
+  table_filter_prefix: str = "",
+  column_filter_prefix: str = "",
+  output_file: Optional[Path] = None,
+) -> list[TableMetadata]: # Get full definitions of many tables
 ```
 
 ## REST API and Queries

--- a/examples/example_use_models.py
+++ b/examples/example_use_models.py
@@ -1,0 +1,29 @@
+from pprint import pprint
+
+from dataverse_client import DataverseConfig, DataverseRestClient
+from dataverse_models import models
+
+
+def check_all_tables(client: DataverseRestClient):
+    for table, model in models.TABLE_MODEL_MAP.items():
+        raw_data = client.query(table, top=5)
+        data = [model(**entry) for entry in raw_data]
+        print(f"###########     Data for table {table}:      ###########")
+        pprint(data[0] if len(data) else "No data")
+
+
+def check_one_table(client: DataverseRestClient, table: str):
+    raw_data = client.query(table, top=5)
+    model = models.TABLE_MODEL_MAP[table]
+    data = [model(**entry) for entry in raw_data]
+    print(f"###########     Raw data for table {table}:      ###########")
+    pprint(raw_data[0])
+    print(f"###########     Model data for table {table}:      ###########")
+    pprint(data[0].model_dump())
+
+
+if __name__ == "__main__":
+    client = DataverseRestClient(DataverseConfig())
+
+    table = "aibs_fact_mouse_water_restrictions"
+    check_one_table(client, table)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,11 @@ dev = [
     'furo'
 ]
 
+codegen = [
+    'jinja2',
+    'devtools',
+]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/src/dataverse_client/__init__.py
+++ b/src/dataverse_client/__init__.py
@@ -4,7 +4,12 @@ from importlib.metadata import version
 
 __version__ = version("dataverse_client")
 
-from .rest_client import DataverseConfig, DataverseRestClient
+from .rest_client import DataverseConfig, DataverseRestClient, ColumnMetadata, TableMetadata
 
 
-__all__ = ["DataverseConfig", "DataverseRestClient"]
+__all__ = [
+    "DataverseConfig",
+    "DataverseRestClient",
+    "ColumnMetadata",
+    "TableMetadata",
+]

--- a/src/dataverse_client/rest_client.py
+++ b/src/dataverse_client/rest_client.py
@@ -3,10 +3,11 @@
 import logging
 from pathlib import Path
 from typing import Optional
+import json
 
 import msal
 from platformdirs import site_data_dir
-from pydantic import SecretStr, computed_field
+from pydantic import BaseModel, SecretStr, computed_field
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -100,6 +101,24 @@ class DataverseConfig(
         )
 
 
+#### Simple models for database table metadata
+
+
+class ColumnMetadata(BaseModel):
+    MetadataId: str
+    LogicalName: str
+    AttributeType: str
+
+
+class TableMetadata(BaseModel):
+    SchemaName: str
+    LogicalCollectionName: str
+    Attributes: Optional[list[ColumnMetadata]] = None
+
+
+####
+
+
 class DataverseRestClient:
     """Client for basic CRUD operations on Dataverse entities."""
 
@@ -136,6 +155,7 @@ class DataverseRestClient:
             "Accept": "application/json",
             "If-None-Match": None,
             "Content-Type": "application/json",
+            "Prefer": 'odata.include-annotations="OData.Community.Display.V1.FormattedValue",return=representation',
         }
 
     def _get_access_token(self) -> str:
@@ -387,7 +407,7 @@ class DataverseRestClient:
         # returns a list of values, and wouldn't include the "@odata.count" property anyway
         response = requests.get(
             url,
-            headers=self.headers | {"Prefer": "return=representation"},
+            headers=self.headers,  # | {"Prefer": "return=representation"},
             timeout=self.config.request_timeout_s,
         )
         logger.debug(
@@ -396,3 +416,85 @@ class DataverseRestClient:
         )
         response.raise_for_status()
         return response.json().get("value", [])
+
+    def list_table_names(self, filter_by_prefix: str = "") -> list[TableMetadata]:
+        """List all table names in the Dataverse environment, optionally filtering by prefix.
+        For each table, return the logical name and the display name (schema name)
+
+        Args:
+            filter_by_prefix: If provided, only return tables whose logical name starts with this prefix.
+        Returns:
+            list[TableMetadata]: List of table metadata objects with no column information
+        """
+        data = self.query("EntityDefinitions", select=["SchemaName", "LogicalCollectionName"])
+        tables = [TableMetadata(**t) for t in data if t["LogicalCollectionName"] is not None]
+        if filter_by_prefix:
+            tables = [t for t in tables if t.LogicalCollectionName.startswith(filter_by_prefix)]
+        return tables
+
+    def table_info(
+        self,
+        table_name: str | TableMetadata,
+        column_filter_prefix: str = "",
+    ) -> TableMetadata:
+        """Get metadata for a Dataverse table, including column names and types.
+
+        Args:
+            table_name: The logical name of the table or a TableMetadata object.
+            column_filter_prefix: If provided, only include columns whose logical name starts with this prefix.
+        Returns:
+            TableMetadata: Metadata for the specified table, including column information
+        """
+        if isinstance(table_name, TableMetadata):
+            table_name = table_name.LogicalCollectionName
+        data = self.query(
+            "EntityDefinitions",
+            filter=f"LogicalCollectionName eq '{table_name}'",
+            select=["SchemaName", "LogicalCollectionName"],
+            expand="Attributes($select=LogicalName,AttributeType)",
+        )[0]
+        table = TableMetadata(**data)
+        if column_filter_prefix:
+            table.Attributes = [
+                a for a in table.Attributes or [] if a.LogicalName.startswith(column_filter_prefix)
+            ]
+        return table
+
+    def list_table_info(
+        self,
+        table_filter_prefix: str = "",
+        column_filter_prefix: str = "",
+        output_file: Optional[Path] = None,
+    ) -> list[TableMetadata]:
+        """Get table metadata for all tables, optionally filtering table logical name by prefix.
+        Microsoft doesn't let you filter metadata by "starts_with(...)" so we have to filter on our own.
+
+        Args:
+            table_filter_prefix: If provided, only include tables whose logical name starts with this prefix.
+            column_filter_prefix: If provided, only include columns whose logical name starts with this prefix.
+            output_file: If provided, write the metadata to this file in JSON format.
+        Returns:
+            list[TableMetadata]: List of table metadata objects, including column information
+        """
+        all_tables = self.query(
+            "EntityDefinitions",
+            select=["SchemaName", "LogicalCollectionName"],
+            expand="Attributes($select=LogicalName,AttributeType)",
+        )
+        if table_filter_prefix:
+            tables_of_interest = [
+                TableMetadata(**t)
+                for t in all_tables
+                if t["LogicalCollectionName"] is not None
+                and t["LogicalCollectionName"].startswith(table_filter_prefix)
+            ]
+        if column_filter_prefix:
+            for t in tables_of_interest:
+                t.Attributes = [
+                    a for a in t.Attributes or [] if a.LogicalName.startswith(column_filter_prefix)
+                ]
+        if output_file:
+            Path(output_file).parent.mkdir(exist_ok=True, parents=True)
+            with open(output_file, "w") as f:
+                json.dump([t.model_dump() for t in tables_of_interest], f, indent=2)
+        return tables_of_interest

--- a/src/dataverse_models/README.md
+++ b/src/dataverse_models/README.md
@@ -1,0 +1,78 @@
+Small utility to read dataverse table definitions and generate pydantic models to help interpret dataverse table reads.
+
+1. Install dataverse-client and codegen dependency:
+    - `uv sync --extra codegen`
+
+2. Run codegen:
+    - `uv run src/dataverse_models/generate_table_models.py`
+
+3. `src/dataverse_models/tables.json` and `src/dataverse_models/models.py` will be created.
+
+The models are generated with the help of the `models.py.jinja2` template, and can capture the formatted values of lookup/picklist fields. They look something like this:
+
+
+```python
+class AibsFactMouseWaterRestriction(BaseModel):
+    _table_name: ClassVar[str] = "aibs_fact_mouse_water_restrictions"
+    _table_display_name: ClassVar[str] = "aibs_fact_mouse_water_restriction"
+    aibs_active_record: Optional[bool] = None
+    aibs_baseline_weight: Optional[float] = None
+    aibs_behavior_training_record_guid: Optional[Any] = Field(
+        None, alias="_aibs_behavior_training_record_value"
+    )
+    aibs_behavior_training_record_formatted: Optional[str] = Field(
+        None, alias="_aibs_behavior_training_record_value@OData.Community.Display.V1.FormattedValue"
+    )
+    aibs_fact_mouse_water_restrictionid: str
+    aibs_last_watered_datetime: Optional[datetime] = None
+    aibs_low_weight_threshold: Optional[float] = None
+    aibs_mouse_id_guid: Optional[Any] = Field(None, alias="_aibs_mouse_id_value")
+    aibs_mouse_id_formatted: Optional[str] = Field(
+        None, alias="_aibs_mouse_id_value@OData.Community.Display.V1.FormattedValue"
+    )
+    aibs_notes: Optional[str] = None
+    aibs_operational_team_guid: Optional[Any] = Field(None, alias="_aibs_operational_team_value")
+    aibs_operational_team_formatted: Optional[str] = Field(
+        None, alias="_aibs_operational_team_value@OData.Community.Display.V1.FormattedValue"
+    )
+    aibs_record_name: Optional[str] = None
+    aibs_target_weight: Optional[float] = None
+    aibs_targeted_weight_percentage: Optional[float] = None
+    aibs_water_restriction_status: Optional[int] = None
+    aibs_water_restriction_status_formatted: Optional[str] = Field(
+        None, alias="aibs_water_restriction_status@OData.Community.Display.V1.FormattedValue"
+    )
+    aibs_watered_today: Optional[bool] = None
+    aibs_watering_shift: Optional[int] = None
+    aibs_watering_shift_formatted: Optional[str] = Field(
+        None, alias="aibs_watering_shift@OData.Community.Display.V1.FormattedValue"
+    )
+
+```
+
+When used to deserialize a dataverse record (see example in example_use_models.py), you get something like the following:
+
+```python
+AibsFactMouseWaterRestriction(
+    aibs_active_record=False,
+    aibs_baseline_weight=27.07,
+    aibs_behavior_training_record_guid='118e7fc6-9a28-f111-8341-000d3a4ded72',
+    aibs_behavior_training_record_formatted='793289_2025-06-20T21:07:25.008236',
+    aibs_fact_mouse_water_restrictionid='85518479-e92e-f111-88b4-000d3a4ded72',
+    aibs_last_watered_datetime=None,
+    aibs_low_weight_threshold=19.51,
+    aibs_mouse_id_guid='6a35228c-8d28-f111-8342-6045bdd3c87e',
+    aibs_mouse_id_formatted='793289',
+    aibs_notes=None,
+    aibs_operational_team_guid='3ac065fa-092e-f111-88b4-7c1e521c04a0',
+    aibs_operational_team_formatted='Behavior Training',
+    aibs_record_name='793289_2025-06-20T21:07:25.008236',
+    aibs_target_weight=23.01,
+    aibs_targeted_weight_percentage=0.85,
+    aibs_water_restriction_status=252080003,
+    aibs_water_restriction_status_formatted='adlib: water restriction complete',
+    aibs_watered_today=False,
+    aibs_watering_shift=None,
+    aibs_watering_shift_formatted=None,
+)
+```

--- a/src/dataverse_models/example_use_models.py
+++ b/src/dataverse_models/example_use_models.py
@@ -1,4 +1,4 @@
-from pprint import pprint
+from devtools import pprint
 
 from dataverse_client import DataverseConfig, DataverseRestClient
 from dataverse_models import models
@@ -19,7 +19,7 @@ def check_one_table(client: DataverseRestClient, table: str):
     print(f"###########     Raw data for table {table}:      ###########")
     pprint(raw_data[0])
     print(f"###########     Model data for table {table}:      ###########")
-    pprint(data[0].model_dump())
+    pprint(data[0])
 
 
 if __name__ == "__main__":

--- a/src/dataverse_models/generate_table_models.py
+++ b/src/dataverse_models/generate_table_models.py
@@ -1,0 +1,195 @@
+from datetime import datetime
+from pathlib import Path
+import subprocess
+from typing import Optional
+
+from pydantic import BaseModel
+import jinja2
+
+from dataverse_client import DataverseConfig, DataverseRestClient, TableMetadata
+
+# Mapping of Odata (EDM) types to Python types
+simple_types = {
+    "Boolean": bool,
+    "String": str,
+    "Memo": str,
+    "DateTime": datetime,
+    "Decimal": float,
+    "Integer": int,
+    "Double": float,
+    # "Virtual": str,  # virtuals aren't actual columns, they're calculated
+}
+
+
+### Models to parametrize our code generation
+class AttributeModel(BaseModel):
+    """Model to represent an attribute of a Pydantic model for code generation"""
+
+    name: str
+    type_hint: str
+    value: Optional[str] = None
+
+    def to_code(self):
+        if self.value is None:
+            return f"{self.name}: {self.type_hint}"
+        else:
+            return f"{self.name}: {self.type_hint} = {self.value}"
+
+
+class ModelModel(BaseModel):
+    """Model to represent a Pydantic model for code generation"""
+
+    name: str
+    parent_class: str = "BaseModel"
+    docstring: Optional[str] = None
+    attributes: list[AttributeModel] = []
+
+
+def make_model_from_table_metadata(table_metadata: TableMetadata) -> ModelModel:
+    """Turn OData table metadata into a ModelModel that can be used to generate a Pydantic model for that table.
+
+    Handles simple types, UniqueIdentifiers, lookups and picklists.
+    For lookups and picklists, add additional fields to capture the formatted values as well as the ids.
+    """
+    # Make CapWords class name from SchemaName, e.g. "aibs_dim_mices" -> "AibsDimMices"
+    model_name = "".join(word.capitalize() for word in table_metadata.SchemaName.split("_"))
+
+    model = ModelModel(
+        name=model_name,
+        attributes=[
+            AttributeModel(
+                name="_table_name",
+                type_hint="ClassVar[str]",
+                value=f'"{table_metadata.LogicalCollectionName}"',
+            ),
+            AttributeModel(
+                name="_table_display_name",
+                type_hint="ClassVar[str]",
+                value=f'"{table_metadata.SchemaName}"',
+            ),
+        ],
+    )
+
+    lookup_fields = []
+    for col in table_metadata.Attributes:
+        if col.AttributeType in simple_types:
+            model.attributes.append(
+                AttributeModel(
+                    name=col.LogicalName,
+                    type_hint=f"Optional[{simple_types[col.AttributeType].__name__}]",
+                    value="None",
+                )
+            )
+        elif col.AttributeType == "Uniqueidentifier":
+            model.attributes.append(
+                AttributeModel(
+                    name=col.LogicalName,
+                    type_hint="str",  # consider changing to "Optional[str]" to use the models for create requests (before GUID is set)
+                )
+            )
+        elif col.AttributeType == "Lookup":
+            # lookup fields have the following weirdnesses:
+            # For a field named "example_field":
+            #   The table metadata contains attributes like:
+            #     - example_field (type: Lookup)
+            #     - example_fieldname (type: String) - shadow field
+            #   When you query the table, the API returns:
+            #     - _example_field_value: "<GUID value as string>"
+            #     - _example_field_value@OData.Community.Display.V1.FormattedValue: "<Formatted value>"
+
+            # So the plan is, ignore the shadow field, and have the following in the model:
+            # - example_field_guid: Optional[str] = Field(None, alias="_example_field_value")
+            # - example_field_formatted: Optional[str] = Field(None, alias="_example_field_value@OData.Community.Display.V1.FormattedValue")
+
+            # Keep track of lookup fields so we can remove the shadow field later
+            lookup_fields.append(col.LogicalName)
+            fieldname = f"_{col.LogicalName}_value"
+            formatted_field_name = (
+                f"_{col.LogicalName}_value@OData.Community.Display.V1.FormattedValue"
+            )
+
+            model.attributes.append(
+                AttributeModel(
+                    name=f"{col.LogicalName}_guid",
+                    type_hint="Optional[Any]",
+                    value=f"Field(None, alias='{fieldname}')",
+                )
+            )
+            model.attributes.append(
+                AttributeModel(
+                    name=f"{col.LogicalName}_formatted",
+                    type_hint="Optional[str]",
+                    value=f"Field(None, alias='{formatted_field_name}')",
+                ),
+            )
+        elif col.AttributeType == "Picklist":
+            # Picklists have the following weirdnesses:
+            # For a field named "example_picklist":
+            #   The table metadata contains attributes like:
+            #     - example_picklist (type: Picklist)
+            #     - example_picklistname (type: Virtual) - shadow field
+            #   When you query the table, the API returns:
+            #     - example_picklist: <picklist enum value int>
+            #     - example_picklist@OData.Community.Display.V1.FormattedValue: "<Formatted value>"
+
+            # So the plan is, ignore the virtual field, and have the following in the model:
+            # - example_picklist: Optional[int] = Field(None, alias="_example_picklist_value")
+            # - example_picklist_formatted: Optional[str] = Field(None, alias="_example_picklist_value@OData.Community.Display.V1.FormattedValue")
+
+            formatted_field_name = f"{col.LogicalName}@OData.Community.Display.V1.FormattedValue"
+            model.attributes.append(
+                AttributeModel(
+                    name=col.LogicalName,
+                    type_hint="Optional[int]",
+                    value="None",
+                )
+            )
+            model.attributes.append(
+                AttributeModel(
+                    name=f"{col.LogicalName}_formatted",
+                    type_hint="Optional[str]",
+                    value=f"Field(None, alias='{formatted_field_name}')",
+                ),
+            )
+        elif col.AttributeType == "Virtual":
+            # Ignore redundant legacy virtual fields that accompany picklists
+            pass
+        else:
+            print(f"Unfamiliar attribute type {col.AttributeType} for column {col.LogicalName}")
+
+    # Remove redundant legacy "shadow" fields that accompany lookups
+    for field in lookup_fields:
+        shadow_field = f"{field}name"
+        try:
+            idx = [i for i, attr in enumerate(model.attributes) if attr.name == shadow_field][0]
+            model.attributes.pop(idx)
+        except IndexError:
+            pass
+
+    return model
+
+
+def codegen_models_from_tables(tables: list[TableMetadata], template_path: Path, output_file: Path):
+    models = {
+        table.LogicalCollectionName: make_model_from_table_metadata(table) for table in tables
+    }
+    template = template_path.read_text()
+    content = jinja2.Template(template).render(models=models)
+
+    output_file.write_text(content)
+    subprocess.run(["uvx", "ruff", "format", str(output_file)], check=True)
+
+
+if __name__ == "__main__":
+    models_dir = Path(__file__).parent
+    client = DataverseRestClient(DataverseConfig())
+    tables = client.list_table_info(
+        table_filter_prefix="aibs_",
+        column_filter_prefix="aibs_",
+        output_file=models_dir / "tables.json",
+    )
+    codegen_models_from_tables(
+        tables,
+        template_path=models_dir / "models.py.jinja2",
+        output_file=models_dir / "models.py",
+    )

--- a/src/dataverse_models/models.py.jinja2
+++ b/src/dataverse_models/models.py.jinja2
@@ -1,0 +1,30 @@
+from datetime import datetime
+from typing import Any, ClassVar, Optional
+
+from pydantic import BaseModel, Field
+
+{% for table, model in models.items() %}
+class {{ model.name }}({{ model.parent_class }}):
+    {% if model.docstring %}
+    """{{ model.docstring }}"""
+    {% endif %}
+
+    {% for attr in model.attributes -%}
+    {{ attr.to_code() }}
+    {% endfor %}
+
+{% endfor %}
+
+
+TABLE_MODEL_MAP: dict[str, type[BaseModel]] = {
+    {% for table, model in models.items() %}
+    "{{ table }}": {{ model.name }},
+    {% endfor %}
+}
+
+__all__ = [
+    "TABLE_MODEL_MAP",
+    {% for table, model in models.items() %}
+    "{{ model.name }}",
+    {% endfor %}
+]


### PR DESCRIPTION
Adds utility to read dataverse table definitions and generate pydantic models to help interpret dataverse table reads.

This allows us to automatically generate accurate models based on dataverse tables without having to write/maintain them by hand.

It may be good to save these models to a library repo that can be properly versioned and used by apps. Here's the models that I generated:

[models.py](https://github.com/user-attachments/files/27289380/models.py)
